### PR TITLE
Fixing Curl Header

### DIFF
--- a/src/network/Curl.php
+++ b/src/network/Curl.php
@@ -364,7 +364,7 @@ class Curl {
 		if ($this->_headers) {
 			$final_headers = array();
 			foreach ($this -> _headers as $key => $value) {
-				$final_headers[] = $key . ' : ' . $value;
+				$final_headers[] = $key . ':' . $value;
 			}
 
 			curl_setopt($this->_handler, CURLOPT_HTTPHEADER, $final_headers);


### PR DESCRIPTION
Space causes the error "Your browser sent a request that this server could not understand" in some web services.